### PR TITLE
Added tree diffing

### DIFF
--- a/visual editor/difftree.js
+++ b/visual editor/difftree.js
@@ -1,0 +1,62 @@
+
+function difftree(tree1, tree2){
+    var diffout = "";
+    var tree1Map = {};
+    var tree2Map = {};
+    flattenTree(tree1, tree1Map);
+    flattenTree(tree2, tree2Map);
+    Object.keys(tree1Map).forEach(function(parent){
+        if(!tree2Map[parent]){
+            diffout += "-" + parent + "\n";
+        }else{
+            Object.keys(tree1Map[parent]).forEach(function(child){
+                if(!tree2Map[parent][child]){
+                    diffout += "-" + parent + " NT " + child + "\n";
+                }
+            });
+        }
+    });
+    Object.keys(tree2Map).forEach(function(parent){
+        if(!tree1Map[parent]){
+            diffout += "+" + parent + "\n";
+        }else{
+            Object.keys(tree2Map[parent]).forEach(function(child){
+                if(!tree1Map[parent][child]){
+                    diffout += "+" + parent + " NT " + child + "\n";
+                }
+            });
+        }
+    });
+    return diffout;
+}
+
+function downloadString (dataStr) {
+    var file = "data:text/plain;charset=utf-8,";
+    var encoded = encodeURIComponent(dataStr);
+    file += encoded;
+    var a = document.createElement('a');
+    a.href = file;
+    a.target   = '_blank';
+    a.download = "diffout.txt";
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+}
+
+function flattenTree(tree, treeMap){
+    if(!treeMap[tree.name]){
+        treeMap[tree.name] = {};
+    }
+    if(tree.children){
+        tree.children.forEach(function(child){
+           treeMap[tree.name][child.name] = 1;
+           flattenTree(child,treeMap);
+        });
+    }
+    if(tree._children){
+        tree._children.forEach(function(child){
+           treeMap[tree.name][child.name] = 1;
+           flattenTree(child,treeMap);
+        });
+    }
+}

--- a/visual editor/dndTree-nodeproblems.js
+++ b/visual editor/dndTree-nodeproblems.js
@@ -350,7 +350,7 @@ var stellarphysics = "stellar_physics.json"
 
 function renderTree(j){
 treeJSON = d3.json(j, function(error, treeData) {
-
+    
     // Calculate total nodes, max label length
     var totalNodes = 0;
     var maxLabelLength = 0;
@@ -364,6 +364,7 @@ treeJSON = d3.json(j, function(error, treeData) {
     var i = 0;
     var duration = 750;
     var root;
+    var orig;
 
     // size of the diagram
     var viewerWidth = $(document).width();
@@ -870,6 +871,7 @@ treeJSON = d3.json(j, function(error, treeData) {
 
     // Define the root
     root = treeData;
+    orig=JSON.parse(JSON.stringify(treeData));
     root.x0 = viewerHeight / 2;
     root.y0 = 0;
 
@@ -899,6 +901,14 @@ function fullcollapse(d) {
             d.children = null;
         }
     };
+
+getRoot = function(){
+    return root;
+};
+
+getOrig = function(){
+    return orig;
+};
 
 finalize = function final2() {
     bugout.clear();

--- a/visual editor/index.html
+++ b/visual editor/index.html
@@ -68,6 +68,7 @@
   </select></br>
 
 <script src="dndTree-nodeproblems.js"></script>
+<script src="difftree.js"></script>
     <div id="tree-container"></div>
     <script type="text/javascript">
         var bugout = new debugout();
@@ -78,9 +79,18 @@
         finalize();
         bugout.downloadLog();
         }
+        function DoDiff(){    
+           finalize();
+
+           var root = getRoot();
+           var orig = getOrig();
+           var diffStr = difftree(orig, root);
+           downloadString(diffStr);
+       }
         </script>
 
 
     <div><input type="button" value="Download Changes" onClick="DoAllThese()"></div>
+    <div><input type="button" value="Download Diff" onClick="DoDiff()"></div>
 </body>
 </html>


### PR DESCRIPTION
I made an initial cut at exporting the tree as a diff. I added an output button to the main page of the tool to offer the diff as a separate option. It works in the testing I have done. This required a few changes to the tree model to expose the root with a getter and to add something that stores the original tree. I only added those to dndTree-nodeproblems.js.